### PR TITLE
Ignore direnv configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ keys/*
 bin/*
 !bin/.gitkeep
 .DS_Store
+.envrc


### PR DESCRIPTION
I use direnv (http://direnv.net) to set the env variables in my clone.
They are mac specific otherwise I'd be doing a PR for that file
(for those direnv users).

For instance:

```
git clone https://github.com/concourse/concourse-docker
cd concourse-docker
echo "export CONCOURSE_LOGIN=admin\nexport CONCOURSE_PASSWORD=password\nexport CONCOURSE_EXTERNAL_URL=http://`ipconfig getifaddr en0`:8080" > .envrc
direnv allow .
docker-compose up
```