### PR TITLE
Update the key material names to match that of the docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ ADD bin/concourse /usr/local/bin
 VOLUME /concourse-keys
 
 # 'web' keys
-ENV CONCOURSE_TSA_HOST_KEY        /concourse-keys/tsa_host_key
+ENV CONCOURSE_TSA_HOST_KEY        /concourse-keys/host_key
 ENV CONCOURSE_TSA_AUTHORIZED_KEYS /concourse-keys/authorized_worker_keys
 ENV CONCOURSE_SESSION_SIGNING_KEY /concourse-keys/session_signing_key
 
 # 'worker' keys
-ENV CONCOURSE_TSA_PUBLIC_KEY         /concourse-keys/tsa_host_key.pub
+ENV CONCOURSE_TSA_PUBLIC_KEY         /concourse-keys/host_key.pub
 ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY /concourse-keys/worker_key
 
 # directory to keep worker state; can be bind-mounted over

--- a/generate-keys.sh
+++ b/generate-keys.sh
@@ -4,10 +4,10 @@ set -e -u -x
 
 mkdir -p keys/web keys/worker
 
-yes | ssh-keygen -t rsa -f ./keys/web/tsa_host_key -N ''
+yes | ssh-keygen -t rsa -f ./keys/web/host_key -N ''
 yes | ssh-keygen -t rsa -f ./keys/web/session_signing_key -N ''
 
 yes | ssh-keygen -t rsa -f ./keys/worker/worker_key -N ''
 
 cp ./keys/worker/worker_key.pub ./keys/web/authorized_worker_keys
-cp ./keys/web/tsa_host_key.pub ./keys/worker
+cp ./keys/web/host_key.pub ./keys/worker


### PR DESCRIPTION
In favor of closing out concourse/concourse#861 and addressing it directly in the Dockerfile instead

cc @vito 