### PR TITLE
Correct usage of no authentication parameter in web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - CONCOURSE_EXTERNAL_URL
     - CONCOURSE_BASIC_AUTH_USERNAME
     - CONCOURSE_BASIC_AUTH_PASSWORD
-    - CONCOURSE_NO_REALLY_I_DONT_WANT_ANY_AUTH
+    - CONCOURSE_NO_REALLY_I_DONT_WANT_ANY_AUTH=true
 
   concourse-worker:
     image: concourse/concourse


### PR DESCRIPTION
Changes the `CONCOURSE_NO_REALLY_I_DONT_WANT_ANY_AUTH`-parameter usage to the same like in docker-compose-quickstart.yml
Without the equals true, the parameter is not used and an error occurs on startup:

> concourse-web_1     | 1 error occurred:
concourse-web_1     | 
concourse-web_1     | * must configure basic auth, OAuth, UAAAuth, or provide no-auth flag
concoursedocker_concourse-web_1 exited with code 1
