### PR TITLE
updated readme docker run local user syntax to support 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker network create concourse-net
 ```
 
 ```
+docker pull concourse-postgres
 docker run --name concourse-db \
   --net=concourse-net \
   -h concourse-postgres \
@@ -55,16 +56,19 @@ docker run --name concourse-db \
   ```
 
 ```
+docker pull concourse/concourse
 docker run  --name concourse \
   -h concourse \
   -p 8080:8080 \
+  --detach \
   --privileged \
   --net=concourse-net \
   concourse/concourse quickstart \
-  --basic-auth-username=<CONCOURSE USER> \
-  --basic-auth-password=<CONCOURSE PASSWORD> \
-  --postgres-user=<PG USER> \
-  --postgres-password=<PG PASSWORD> \
+  --add-local-user=<CONCOURSE_USER>:<CONCOURSE_PASSWORD> \
+  --main-team-local-user=<CONCOURSE_USER> \
+  --external-url=http://<DOCKER_MACHINE_IP>:8080 \
+  --postgres-user=<PG_USER> \
+  --postgres-password=<PG_PASSWORD> \
   --postgres-host=concourse-db \
   --worker-garden-dns-server 8.8.8.8
   ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker network create concourse-net
 ```
 
 ```
-docker pull concourse-postgres
+docker pull postgres
 docker run --name concourse-db \
   --net=concourse-net \
   -h concourse-postgres \


### PR DESCRIPTION
the syntax used for local auth was not correct for 4.0 per https://concourse-ci.org/install.html#auth-config

browser callback failed when doing `fly login` until I specified the external-url to be the docker machine IP

added pull commands to ensure everyone is actually using the latest image

