### PR TITLE
Fixes the generation of keys on systems with newer OpenSSH versions (>= 7.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Topology](https://concourse-ci.org/topology.html).
 There are two Docker Compose `.yml` files in this repo. The first one,
 `docker-compose.yml`, runs a more traditional multi-container cluster. You'll
 need to run `./generate-keys.sh` before booting up, so that the containers know
-how to authorize each other.
+how to authorize each other. On systems with OpenSSH >= 7.8, you may need to
+run `./generate-keys.sh --use-pem` to generate the keys using the correct
+format.
 
 The `docker-compose-quickstart.yml` file can be used to quickly get up and
 running with the `concourse quickstart` command. No keys need to be generated
@@ -37,7 +39,7 @@ information..
 
 ## Docker Run
 
-Alternatively, these two Docker Run commands can be used to get `concourse-quickstart` up and running with 2 containers.  These command provide not only `concourse`, but also a database instance for it to use. 
+Alternatively, these two Docker Run commands can be used to get `concourse-quickstart` up and running with 2 containers.  These command provide not only `concourse`, but also a database instance for it to use.
 
 ```
 docker network create concourse-net

--- a/generate-keys.sh
+++ b/generate-keys.sh
@@ -2,12 +2,29 @@
 
 set -e -u -x
 
+# check if we should use the old PEM style for generating the keys
+# --------
+# check: https://www.openssh.com/txt/release-7.8
+
+PEM_OPTION=
+
+if [ "$#" -eq 1 ] && [ "$1" == '--use-pem' ]; then
+    PEM_OPTION='-m PEM'
+elif [ "$#" -eq 1 ]; then
+    echo "Invalid argument '$1', did you mean '--use-pem'?"
+    exit 1
+fi
+
+# generate the keys
+# --------
+
 mkdir -p keys/web keys/worker
 
-yes | ssh-keygen -t rsa -f ./keys/web/tsa_host_key -N ''
-yes | ssh-keygen -t rsa -f ./keys/web/session_signing_key -N ''
+yes | ssh-keygen $PEM_OPTION -t rsa -f ./keys/web/tsa_host_key -N ''
+yes | ssh-keygen $PEM_OPTION -t rsa -f ./keys/web/session_signing_key -N ''
 
-yes | ssh-keygen -t rsa -f ./keys/worker/worker_key -N ''
+yes | ssh-keygen $PEM_OPTION -t rsa -f ./keys/worker/worker_key -N ''
 
 cp ./keys/worker/worker_key.pub ./keys/web/authorized_worker_keys
 cp ./keys/web/tsa_host_key.pub ./keys/worker
+


### PR DESCRIPTION
The OpenSSH release:

https://www.openssh.com/txt/release-7.8

Changes the default format when generating private keys, this pull requests fixes that by letting the users on systems with newer OpenSSH versions specify if they want to use the old PEM format by passing the flag `--use-pem` to the `generate-keys.sh` script.

#23 