### PR TITLE
Add curl to image to help with Istio liveness checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get -y install iproute2 ca-certificates file
+RUN apt-get update && apt-get -y install iproute2 ca-certificates file curl
 
 ADD bin/dumb-init /usr/local/bin
 ADD bin/concourse /usr/local/bin


### PR DESCRIPTION
When Concourse is deployed with Istio mTLS required,
then liveness checks from Kubelet won't work, and instead
the recommendation is to exec curl from within the container:

<https://istio.io/help/faq/security/#k8s-health-checks>

This change adds `curl` to the image used by the Kubernetes
helm chart for Concourse.