### PR TITLE
bake STOPSIGNAL into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,6 @@ RUN apt update && apt install -y \
 
 COPY --from=assets /usr/local/concourse /usr/local/concourse
 
+STOPSIGNAL SIGUSR2
+
 ENTRYPOINT ["dumb-init", "/usr/local/concourse/bin/concourse"]


### PR DESCRIPTION
Dockerfile syntax now supports a STOPSIGNAL directive which AFAIK should make the README.md comment on SIGUSR2 redundant https://docs.docker.com/engine/reference/builder/#stopsignal