### PR TITLE
add logging restrictions to default docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       POSTGRES_DB: concourse
       POSTGRES_USER: concourse_user
       POSTGRES_PASSWORD: concourse_pass
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
 
   web:
     image: concourse/concourse
@@ -23,6 +28,11 @@ services:
       CONCOURSE_POSTGRES_DATABASE: concourse
       CONCOURSE_ADD_LOCAL_USER: test:test
       CONCOURSE_MAIN_TEAM_LOCAL_USER: test
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
 
   worker:
     image: concourse/concourse
@@ -34,3 +44,8 @@ services:
     stop_signal: SIGUSR2
     environment:
       CONCOURSE_TSA_HOST: web:2222
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"


### PR DESCRIPTION
In order to prevent growing very large docker images, I've added these logging bound statements which I find very useful.

Otherwise, running the concourse docker-compose for longer time frames quickly filled up my hard drive.

I am not sure if you want to have this configuration in the default docker-compose though, so I am happy to close.