### PR TITLE
use apt-get for more 'stable CLI interface'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV CONCOURSE_WORKER_WORK_DIR         /worker-state
 # volume for non-aufs/etc. mount for baggageclaim's driver
 VOLUME /worker-state
 
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
     btrfs-tools \
     ca-certificates \
     dumb-init \


### PR DESCRIPTION
This is part of a larger pattern of failures we've been seeing on builder-task/registry-image workflows on the main pipeline, but this seemed like some super low-hanging fruit.