### PR TITLE
Add containerd namespace and run iptables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     dumb-init \
     iproute2 \
-    file
+    file \
+    iptables
 
 COPY --from=assets /usr/local/concourse /usr/local/concourse
 


### PR DESCRIPTION
We ran into the need for this when working on https://github.com/concourse/concourse/issues/4993. The `build-rc image` job in https://ci.concourse-ci.org/teams/main/pipelines/concourse is now packaging a binary with containerd support. 

Since this Dockerfile serves as the base image these containerd defaults should be here. `iptables` is used by cni.

concourse/concourse#4993

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>
Co-authored-by: Muntasir Chowdhury <mchowdhury@pivotal.io>