### PR TITLE
only pass keys for specified command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,6 @@ RUN tar xzf /tmp/*tgz -C /usr/local
 
 FROM ubuntu
 
-# 'web' keys
-ENV CONCOURSE_SESSION_SIGNING_KEY     /concourse-keys/session_signing_key
-ENV CONCOURSE_TSA_AUTHORIZED_KEYS     /concourse-keys/authorized_worker_keys
-ENV CONCOURSE_TSA_HOST_KEY            /concourse-keys/tsa_host_key
-
-# 'worker' keys
-ENV CONCOURSE_TSA_PUBLIC_KEY          /concourse-keys/tsa_host_key.pub
-ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY  /concourse-keys/worker_key
-
 # enable DNS proxy to support Docker's 127.x.x.x DNS server
 ENV CONCOURSE_GARDEN_DNS_PROXY_ENABLE         true
 ENV CONCOURSE_WORKER_GARDEN_DNS_PROXY_ENABLE  true
@@ -38,4 +29,5 @@ COPY --from=assets /usr/local/concourse /usr/local/concourse
 
 STOPSIGNAL SIGUSR2
 
-ENTRYPOINT ["dumb-init", "/usr/local/concourse/bin/concourse"]
+COPY ./concourse-docker/entrypoint.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY --from=assets /usr/local/concourse /usr/local/concourse
 STOPSIGNAL SIGUSR2
 
 COPY ./concourse-docker/entrypoint.sh /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["dumb-init", "/usr/local/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+case $1 in
+web)
+  export CONCOURSE_SESSION_SIGNING_KEY=/concourse-keys/session_signing_key
+  export CONCOURSE_TSA_AUTHORIZED_KEYS=/concourse-keys/authorized_worker_keys
+  export CONCOURSE_TSA_HOST_KEY=/concourse-keys/tsa_host_key
+  ;;
+worker)
+  export CONCOURSE_TSA_PUBLIC_KEY=/concourse-keys/tsa_host_key.pub
+  export CONCOURSE_TSA_WORKER_PRIVATE_KEY=/concourse-keys/worker_key
+  ;;
+quickstart)
+  export CONCOURSE_SESSION_SIGNING_KEY=/concourse-keys/session_signing_key
+  export CONCOURSE_TSA_AUTHORIZED_KEYS=/concourse-keys/authorized_worker_keys
+  export CONCOURSE_TSA_HOST_KEY=/concourse-keys/tsa_host_key
+  export CONCOURSE_TSA_PUBLIC_KEY=/concourse-keys/tsa_host_key.pub
+  export CONCOURSE_TSA_WORKER_PRIVATE_KEY=/concourse-keys/worker_key
+  ;;
+esac
+dumb-init /usr/local/concourse/bin/concourse $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,12 @@
 #!/bin/sh
-case $1 in
-web)
-  export CONCOURSE_SESSION_SIGNING_KEY=/concourse-keys/session_signing_key
-  export CONCOURSE_TSA_AUTHORIZED_KEYS=/concourse-keys/authorized_worker_keys
-  export CONCOURSE_TSA_HOST_KEY=/concourse-keys/tsa_host_key
-  ;;
-worker)
-  export CONCOURSE_TSA_PUBLIC_KEY=/concourse-keys/tsa_host_key.pub
-  export CONCOURSE_TSA_WORKER_PRIVATE_KEY=/concourse-keys/worker_key
-  ;;
-quickstart)
-  export CONCOURSE_SESSION_SIGNING_KEY=/concourse-keys/session_signing_key
-  export CONCOURSE_TSA_AUTHORIZED_KEYS=/concourse-keys/authorized_worker_keys
-  export CONCOURSE_TSA_HOST_KEY=/concourse-keys/tsa_host_key
-  export CONCOURSE_TSA_PUBLIC_KEY=/concourse-keys/tsa_host_key.pub
-  export CONCOURSE_TSA_WORKER_PRIVATE_KEY=/concourse-keys/worker_key
-  ;;
-esac
-dumb-init /usr/local/concourse/bin/concourse $@
+CONCOURSE_SESSION_SIGNING_KEY=/concourse-keys/session_signing_key
+[ -f $CONCOURSE_SESSION_SIGNING_KEY ] && export CONCOURSE_SESSION_SIGNING_KEY
+CONCOURSE_TSA_AUTHORIZED_KEYS=/concourse-keys/authorized_worker_keys
+[ -f $CONCOURSE_TSA_AUTHORIZED_KEYS ] && export CONCOURSE_TSA_AUTHORIZED_KEYS
+CONCOURSE_TSA_HOST_KEY=/concourse-keys/tsa_host_key
+[ -f $CONCOURSE_TSA_HOST_KEY ] && export CONCOURSE_TSA_HOST_KEY
+CONCOURSE_TSA_PUBLIC_KEY=/concourse-keys/tsa_host_key.pub
+[ -f $CONCOURSE_TSA_PUBLIC_KEY ] && export CONCOURSE_TSA_PUBLIC_KEY
+CONCOURSE_TSA_WORKER_PRIVATE_KEY=/concourse-keys/worker_key
+[ -f $CONCOURSE_TSA_WORKER_PRIVATE_KEY ] && export CONCOURSE_TSA_WORKER_PRIVATE_KEY
+exec /usr/local/concourse/bin/concourse $@


### PR DESCRIPTION
Fixes concourse/concourse-docker#58

This change is necessary because you really should never find yourself running
`conourse web` and needlessly passing worker-related keys.

What's nice about this change is that you can still use these docker images
the way you're used to, without needing to pass extra env vars at runtime.

This is achieved by adding an entrypoint script. I'm not married to having it
under `/usr/local/bin`, but after briefly investigating I didn't see any
especially idiomatic place to put entrypoint scripts.

I tested these changes manually by running
```
fly -t ci execute \
  -c ci/build-image.yml \
  --privileged \
  -j release-5.5.x/build-rc-image \
  --image builder \
  -i concourse-docker=. \
  -m linux-rc=linux-rc-ubuntu \
  -o image=./image
```
then doing a `docker load -i image/image.tar` and running the resulting image with
various subcommands (`worker`, `web`, `quickstart`, `generate-key`).