### PR TITLE
Apply shellcheck fixes to entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
-[ "${CONCOURSE_RUNTIME}" == "containerd" ] && \
-[ $(mount | grep ' /sys/fs/cgroup ' | grep cgroup2 | wc -l) -eq 1 ] && \
+[ "${CONCOURSE_RUNTIME}" = "containerd" ] && \
+[ "$(mount | grep ' /sys/fs/cgroup ' | grep -c cgroup2)" -eq 1 ] && \
 mkdir /sys/fs/cgroup/entrypoint && \
 echo 1 > /sys/fs/cgroup/entrypoint/cgroup.procs
 
 CONCOURSE_SESSION_SIGNING_KEY=${CONCOURSE_SESSION_SIGNING_KEY:-/concourse-keys/session_signing_key}
-[ -f $CONCOURSE_SESSION_SIGNING_KEY ] && export CONCOURSE_SESSION_SIGNING_KEY
+[ -f "$CONCOURSE_SESSION_SIGNING_KEY" ] && export CONCOURSE_SESSION_SIGNING_KEY
 CONCOURSE_TSA_AUTHORIZED_KEYS=${CONCOURSE_TSA_AUTHORIZED_KEYS:-/concourse-keys/authorized_worker_keys}
-[ -f $CONCOURSE_TSA_AUTHORIZED_KEYS ] && export CONCOURSE_TSA_AUTHORIZED_KEYS
+[ -f "$CONCOURSE_TSA_AUTHORIZED_KEYS" ] && export CONCOURSE_TSA_AUTHORIZED_KEYS
 CONCOURSE_TSA_HOST_KEY=${CONCOURSE_TSA_HOST_KEY:-/concourse-keys/tsa_host_key}
-[ -f $CONCOURSE_TSA_HOST_KEY ] && export CONCOURSE_TSA_HOST_KEY
+[ -f "$CONCOURSE_TSA_HOST_KEY" ] && export CONCOURSE_TSA_HOST_KEY
 CONCOURSE_TSA_PUBLIC_KEY=${CONCOURSE_TSA_PUBLIC_KEY:-/concourse-keys/tsa_host_key.pub}
-[ -f $CONCOURSE_TSA_PUBLIC_KEY ] && export CONCOURSE_TSA_PUBLIC_KEY
+[ -f "$CONCOURSE_TSA_PUBLIC_KEY" ] && export CONCOURSE_TSA_PUBLIC_KEY
 CONCOURSE_TSA_WORKER_PRIVATE_KEY=${CONCOURSE_TSA_WORKER_PRIVATE_KEY:-/concourse-keys/worker_key}
-[ -f $CONCOURSE_TSA_WORKER_PRIVATE_KEY ] && export CONCOURSE_TSA_WORKER_PRIVATE_KEY
-exec /usr/local/concourse/bin/concourse $@
+[ -f "$CONCOURSE_TSA_WORKER_PRIVATE_KEY" ] && export CONCOURSE_TSA_WORKER_PRIVATE_KEY
+exec /usr/local/concourse/bin/concourse "$@"


### PR DESCRIPTION
Applied shellcheck's recommendations to entrypoint.sh as I was trying to get around the cgroup issue in my own image.

 I think the fix on line 2 is particularly needed since comparison with == is not correct in posix, and dash throws an error here. Pretty sure this results in lines 4 and 5 not executing.

Since the default image uses Ubuntu (and therefore dash) I think this fix is necessary for the cgroup v2 fix to actually apply. 