### PR TITLE
Add the case when someone is using quickstart

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-[ "${CONCOURSE_RUNTIME}" = "containerd" ] && \
+
+[ "${CONCOURSE_RUNTIME}" = "containerd" ] || [ "${CONCOURSE_WORKER_RUNTIME}" = "containerd" ] && \
 [ "$(mount | grep ' /sys/fs/cgroup ' | grep -c cgroup2)" -eq 1 ] && \
 mkdir /sys/fs/cgroup/entrypoint && \
 echo 1 > /sys/fs/cgroup/entrypoint/cgroup.procs


### PR DESCRIPTION
if someone is using the quickstart command then env vars have` _WORKER_`
or `_WEB_` added to their names. This means the fix from #77 doesn't work
with the quickstart command. This PR adds that check.

I'm not sh expert but based on my testing this should work. Simple
example:

```
$ false || echo foo && echo bar
foo
bar
$ true || echo foo && echo bar
bar
```