### PR TITLE
[Doc] Add a message for runtime specific environment variables in Concourse Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ docker run -t concourse/concourse web --help
 docker run -t concourse/concourse worker --help
 ```
 
+Concourse worker can be run with multiple [container runtimes](https://concourse-ci.org/concourse-worker.html#configuring-runtimes):
+* [containerd](https://github.com/containerd/containerd/)
+* [Guardian](https://github.com/cloudfoundry/guardian)
+* [Houdini](https://github.com/vito/houdini)
+
+While adding the `CONCOURSE_*` environment variables for worker, please be mindful to configure the desired [container runtime](https://concourse-ci.org/concourse-worker) appropriately.
+
 See [the Concourse install docs](https://concourse-ci.org/install.html) for more
 information on deploying and managing Concourse - the Docker repository just
 wraps the `concourse` binary, so the documentation covers it too.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Concourse worker can be run with multiple [container runtimes](https://concourse
 * [Guardian](https://github.com/cloudfoundry/guardian)
 * [Houdini](https://github.com/vito/houdini)
 
-While adding the `CONCOURSE_*` environment variables for worker, please be mindful to configure the desired [container runtime](https://concourse-ci.org/concourse-worker) appropriately.
+While adding the `CONCOURSE_*` environment variables for worker in `docker-compose.yml`, please be mindful to configure the desired [container runtime](https://concourse-ci.org/concourse-worker.html#configuring-runtimes) appropriately.
 
 See [the Concourse install docs](https://concourse-ci.org/install.html) for more
 information on deploying and managing Concourse - the Docker repository just


### PR DESCRIPTION
This would make trying out the `docker-compose` easy for newcomers, as triggering a job on the worker with incorrect configuration may result in unexpected errors. For example:

https://github.com/concourse/concourse/issues/7237

```
create resource config: base resource type not found: registry-image
create resource config: base resource type not found: registry-image
errored
```