### PR TITLE
Support multi-arch image build

### DIFF
--- a/ci/build-image.yml
+++ b/ci/build-image.yml
@@ -3,11 +3,13 @@ platform: linux
 
 image_resource:
   type: registry-image
-  source: {repository: vito/oci-build-task}
+  source: {repository: concourse/oci-build-task}
 
 inputs:
 - name: concourse-docker
-- name: linux-rc
+- name: linux-amd64
+- name: linux-arm64
+  optional: true
 
 outputs:
 - name: image
@@ -15,6 +17,8 @@ outputs:
 params:
   DOCKERFILE: concourse-docker/Dockerfile
   CONTEXT: .
+  IMAGE_PLATFORM: linux/amd64,linux/arm64
+  OUTPUT_OCI: true
 
 run:
   path: build


### PR DESCRIPTION
Related to https://github.com/concourse/concourse/issues/9182

Uses wolfi-base from Chainguard which will enable us to start shipping arm64 `concourse/concourse` images.